### PR TITLE
Minor fixes

### DIFF
--- a/pynt/pynt.el
+++ b/pynt/pynt.el
@@ -15,7 +15,6 @@
 
 ;;; Code:
 
-(require 'cl)
 (require 'epcs)
 (require 'epc)
 
@@ -60,7 +59,7 @@ def __cell__(content, buffer_name, cell_type, line_number):
 __name__ = '__pynt__'
 
 "
-  "Pythong code template which is evaluated in the current notebook..
+  "Python code template which is evaluated in the current notebook..
 
 The value of `pynt-elisp-relay-server-hostname' and
 `pynt-epc-port' are used to complete this template.")
@@ -115,15 +114,15 @@ line in the body of a for loop.")
   "Extract the module-level name of the pynt text buffer.
 
 If the buffer is associated with a python file then chop off the
-'.py' suffix. Otherwise (e.g. if this is a *scratch* buffer just
-retrun the buffer name. Throw an error if the buffer name has a
+'.py' suffix.  Otherwise (e.g. if this is a *scratch* buffer just
+retrun the buffer name.  Throw an error if the buffer name has a
 period in it because that will mess with the naming of namespaces
 that pynt uses."
   (if (string-suffix-p ".py" (buffer-name))
       (let ((namespace-tokens (nbutlast (split-string (buffer-name) "\\.py") 1)))
         (if (or (> (length namespace-tokens) 1)
                 (string-match-p (regexp-quote "=") (car namespace-tokens)))
-            (error "Buffer name cannot contain '.' nor '='. Rename your buffer and try again!")
+            (error "Buffer name cannot contain '.' nor '='.  Rename your buffer and try again!")
           (car namespace-tokens)))
     (buffer-name)))
 
@@ -160,7 +159,7 @@ This function mainly exists to clear out each namespace worksheet
 in the beginning to start them each with a blank slate."
   (interactive)
   (let* ((buffer-names (mapcar 'buffer-name (buffer-list)))
-        (worksheet-names (seq-filter (lambda (buffer-name) (string-prefix-p "ns=" buffer-name)) buffer-names)))
+         (worksheet-names (seq-filter (lambda (buffer-name) (string-prefix-p "ns=" buffer-name)) buffer-names)))
     (dolist (worksheet-name worksheet-names)
       (pynt-kill-cells worksheet-name))))
 
@@ -178,7 +177,7 @@ This function is used so we can pull out the worksheet name (i.e. name of the ac
   "Return the name of the active namespace.
 
 The active namespace will have a buffer in the active frame and
-will have the prefix 'ns='. If there is no such window then
+will have the prefix 'ns='.  If there is no such window then
 produce an error."
   (let* ((buffer-names (pynt-get-namespace-buffer-names))
          (active-buffer-singleton (seq-filter
@@ -193,7 +192,7 @@ produce an error."
   "Parse through the active frame and pick out the active buffer.
 
 Set `pynt-active-namespace-buffer-name' and
-`pynt-active-namespace' accordingly. `NS-BUFFER-NAME' is a string."
+`pynt-active-namespace' accordingly.  `NS-BUFFER-NAME' is a string."
   (setq pynt-active-namespace-buffer-name ns-buffer-name)
   (let ((namespace-singleton (split-string pynt-active-namespace-buffer-name "ns=")))
     (setq pynt-active-namespace (cadr namespace-singleton))))
@@ -222,7 +221,7 @@ This is the main function which kicks off much of the work."
   "Scroll the worksheet buffer.
 
 Do it so the cell which corresponds to the line of code the point
-is on goes to the top. Make sure the cell we're about to jump to
+is on goes to the top.  Make sure the cell we're about to jump to
 is is indeed the active buffer.
 
 Go off of the variable `pynt-nth-cell-instance' in the case where
@@ -230,7 +229,7 @@ we want to see the nth pass though, say, a for loop.
 
 Wrap the main logic in a condition case because it could be the
 case that the cell that did correspond to a line has since been
-deleted. Basically there is a bunch of data invalidation that I
+deleted.  Basically there is a bunch of data invalidation that I
 don't want to worry about at this point in time."
   (interactive)
   (when (not (string-prefix-p "ns=" (buffer-name)))
@@ -381,7 +380,7 @@ This happens when pynt mode is exited."
   "Initialize the EPC client for the active kernel.
 
 This needs to be done so python can send commands to Emacs to
-create code cells. Use whatever the value is for
+create code cells.  Use whatever the value is for
 `pynt-elisp-relay-server-hostname' and `pynt-epc-port' to define the
 communication channels for the EPC client."
   (let ((pynt-init-code (format pynt-init-code-template pynt-elisp-relay-server-hostname pynt-epc-port)))


### PR DESCRIPTION
- Remove unused `require` of deprecated `cl`
- Fix `checkdoc` warnings

See https://github.com/melpa/melpa/pull/5240
