### PR TITLE
Use Markdown description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,12 @@
-import pypandoc
-
 from setuptools import setup
 
-
-def readme():
-    rst = pypandoc.convert_file('README.md', to='rst')
-    return rst
 
 setup(
     name='codebook',
     version='1.1.0',
     description='Emacs minor mode for generating and interacting with jupyter notebooks',
-    long_description=readme(),
+    long_description=open('README.md').read(),
+    long_description_content_type="text/markdown",
     url='http://github.com/ebanner/pynt',
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This removes the dependency on pypandoc (and pandoc) which is likely to not be installed.

Markdown description has been supported in PyPI for a few months (need a recent version of setuptools, wheel and twine). See [this](https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi) for more details.

I uploaded the package on test.pypi.org to check the rendering, see [this](https://test.pypi.org/project/codebook/). From what I can see the rendering is identical to the one in [PyPI](https://test.pypi.org/project/codebook/) generated through pandoc.

