### PR TITLE
Fixing the initialisation of the kernel manager

### DIFF
--- a/codebook/manager.py
+++ b/codebook/manager.py
@@ -89,7 +89,7 @@ class ExternalIPythonKernelManager(MappingKernelManager):
         >>> kwargs = {}
 
         """
-        kernel_id = super(ExternalIPythonKernelManager, self).start_kernel(**kwargs).result()
+        kernel_id = yield super(ExternalIPythonKernelManager, self).start_kernel(**kwargs)
         if self._should_use_existing():
             self._attach_to_latest_kernel(kernel_id)
         raise gen.Return(kernel_id)


### PR DESCRIPTION
Hello

I had a similar use case in [yapycon](https://github.com/aanastasiou/yapycon) and was really glad to come across extipy and pynt. 

Unfortunately in my case, while all components seem to be working alright, the Jupyter notebook still does not connect to the specific kernel I am directing it to.

In any case, to get Jupyter notebook to launch with PYNT's kernel manager, I had to apply a very slight modification to the way the kernel manager's `super()` is "joined" within `start_kernel()`, otherwise I kept getting the error that the function "...was never awaited" (or something like this).

I don't know if there might be any other bugs elsewhere in the code because I only focused on this particular component and it had an easy fix.

This was discovered and corrected in `Python3.9.5, IPython 7.30.0, ipykernel 6.5.1, jupyter_client 7.1.0, jupyter_core 4.9.1, notebook 6.4.6, qtconsole 5.2.1`.

Hope this helps.